### PR TITLE
Add local dev env

### DIFF
--- a/.docker/php-cli.Dockerfile
+++ b/.docker/php-cli.Dockerfile
@@ -1,0 +1,4 @@
+FROM php:8.1-cli
+
+# Install XDebug
+RUN pecl install xdebug-3.3.2 && docker-php-ext-enable xdebug

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+name: konomi
+
+services:
+
+  php:
+    container_name: konomi-php
+    build:
+      context: ./.docker
+      dockerfile: php-cli.Dockerfile
+    volumes:
+      - type: bind
+        source: .
+        target: /konomi
+    working_dir: /konomi

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,7 @@
     <source>
         <include>
             <directory suffix=".php">./sources/server/src</directory>
+            <file>./konomi.php</file>
         </include>
     </source>
 </phpunit>


### PR DESCRIPTION
Using a custom docker container for php including xdebug based on the project requirements.

The php cli container is running php 8.1 with xdebug. Useful for code coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the PHP base image to version 8.1 in the Docker configuration.
	- Added XDebug version 3.3.2 to enhance debugging capabilities.
	- Introduced a new service in the Docker Compose setup for the `konomi` project, including specific container settings.
	- Expanded PHPUnit configuration to include the `konomi.php` file for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->