### PR TITLE
Update namespaces to SpaghettiDojo\Konomi

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@
 
 ### Structure and Namespaces
 - Follow PSR-4 autoloading standard
-- Use namespace `Widoz\Wp\Konomi` for all PHP code
+- Use namespace `SpaghettiDojo\Konomi` for all PHP code
 - Place PHP files in the `sources/` directory
 - Organize code by feature (module-based architecture)
 
@@ -98,10 +98,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Module;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Module;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\Module;
+use SpaghettiDojo\Konomi\Module;
 
 describe('ModuleName', function (): void {
     describe('methodName', function (): void {

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 > A WordPress plugin to save posts as favorite using the new Interactive API
 
-[![Artifacts](https://github.com/widoz/konomi/actions/workflows/artifacts.yml/badge.svg)](https://github.com/widoz/konomi/actions/workflows/artifacts.yml)
-[![Client Linting](https://github.com/widoz/konomi/actions/workflows/client-linting.yml/badge.svg)](https://github.com/widoz/konomi/actions/workflows/client-linting.yml)
-[![Server Linting](https://github.com/widoz/konomi/actions/workflows/server-linting.yml/badge.svg)](https://github.com/widoz/konomi/actions/workflows/server-linting.yml)
-[![codecov](https://codecov.io/github/widoz/konomi/graph/badge.svg?token=L4XE77C0JL)](https://codecov.io/github/widoz/konomi)
+[![Artifacts](https://github.com/spaghetti-dojo/konomi/actions/workflows/artifacts.yml/badge.svg)](https://github.com/spaghettidojo/konomi/actions/workflows/artifacts.yml)
+[![Client Linting](https://github.com/spaghetti-dojo/konomi/actions/workflows/client-linting.yml/badge.svg)](https://github.com/spaghettidojo/konomi/actions/workflows/client-linting.yml)
+[![Server Linting](https://github.com/spaghetti-dojo/konomi/actions/workflows/server-linting.yml/badge.svg)](https://github.com/spaghettidojo/konomi/actions/workflows/server-linting.yml)
+[![codecov](https://codecov.io/github/spaghettidojo/konomi/graph/badge.svg?token=L4XE77C0JL)](https://codecov.io/github/spaghettidojo/konomi)
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "widoz/konomi",
+	"name": "spaghetti-dojo/konomi",
 	"description": "A WordPress plugin to save posts as favorite using the new Interactive API",
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
@@ -28,7 +28,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"Widoz\\Wp\\Konomi\\": "sources/"
+			"SpaghettiDojo\\Konomi\\": "sources/"
 		},
 		"files": [
 			"sources/Functions/filters.php",
@@ -39,10 +39,10 @@
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"Widoz\\Wp\\Konomi\\Tests\\": "tests/",
-			"Widoz\\Wp\\Konomi\\Tests\\Unit\\": "tests/unit/php",
-			"Widoz\\Wp\\Konomi\\Tests\\Integration\\": "tests/integration/php",
-			"Widoz\\Wp\\Konomi\\Tests\\Functional\\": "tests/functional/php"
+			"SpaghettiDojo\\Konomi\\Tests\\": "tests/",
+			"SpaghettiDojo\\Konomi\\Tests\\Unit\\": "tests/unit/php",
+			"SpaghettiDojo\\Konomi\\Tests\\Integration\\": "tests/integration/php",
+			"SpaghettiDojo\\Konomi\\Tests\\Functional\\": "tests/functional/php"
 		}
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69149f47be6cc098b92bf85b870fe65b",
+    "content-hash": "a85aad5af6a8cdaf9819c7f5aac9b2f3",
     "packages": [
         {
             "name": "inpsyde/modularity",
@@ -635,16 +635,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.18.0",
+            "version": "2.18.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e"
+                "reference": "89dabca1490bc77dbcab41c2b20968c7e44bf7c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e",
-                "reference": "a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/89dabca1490bc77dbcab41c2b20968c7e44bf7c3",
+                "reference": "89dabca1490bc77dbcab41c2b20968c7e44bf7c3",
                 "shasum": ""
             },
             "require": {
@@ -694,7 +694,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.18.0"
+                "source": "https://github.com/filp/whoops/tree/2.18.2"
             },
             "funding": [
                 {
@@ -702,7 +702,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-15T12:00:00+00:00"
+            "time": "2025-06-11T20:42:19+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -1767,29 +1767,29 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "46d08eb86eec622b96c466adec3063adfed280dd"
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/46d08eb86eec622b96c466adec3063adfed280dd",
-                "reference": "46d08eb86eec622b96c466adec3063adfed280dd",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/fa4b8d051e278072928e32d817456a7fdb57b6ca",
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.9",
-                "squizlabs/php_codesniffer": "^3.12.1"
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -1845,33 +1845,33 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-04-20T23:35:32+00:00"
+            "time": "2025-06-14T07:40:39+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.12",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
+                "reference": "65355670ac17c34cd235cf9d3ceae1b9252c4dad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/65355670ac17c34cd235cf9d3ceae1b9252c4dad",
+                "reference": "65355670ac17c34cd235cf9d3ceae1b9252c4dad",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -1908,6 +1908,7 @@
                 "phpcodesniffer-standard",
                 "phpcs",
                 "phpcs3",
+                "phpcs4",
                 "standards",
                 "static analysis",
                 "tokens",
@@ -1931,9 +1932,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-05-20T13:34:27+00:00"
+            "time": "2025-06-12T04:32:33+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3801,16 +3806,16 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.18.1",
+            "version": "8.19.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "06b18b3f64979ab31d27c37021838439f3ed5919"
+                "reference": "458d665acd49009efebd7e0cb385d71ae9ac3220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/06b18b3f64979ab31d27c37021838439f3ed5919",
-                "reference": "06b18b3f64979ab31d27c37021838439f3ed5919",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/458d665acd49009efebd7e0cb385d71ae9ac3220",
+                "reference": "458d665acd49009efebd7e0cb385d71ae9ac3220",
                 "shasum": ""
             },
             "require": {
@@ -3850,7 +3855,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.18.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.19.1"
             },
             "funding": [
                 {
@@ -3862,20 +3867,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-22T14:32:30+00:00"
+            "time": "2025-06-09T17:53:57+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.0",
+            "version": "3.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "65ff2489553b83b4597e89c3b8b721487011d186"
+                "reference": "1b71b4dd7e7ef651ac749cea67e513c0c832f4bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/65ff2489553b83b4597e89c3b8b721487011d186",
-                "reference": "65ff2489553b83b4597e89c3b8b721487011d186",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1b71b4dd7e7ef651ac749cea67e513c0c832f4bd",
+                "reference": "1b71b4dd7e7ef651ac749cea67e513c0c832f4bd",
                 "shasum": ""
             },
             "require": {
@@ -3946,7 +3951,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-05-11T03:36:00+00:00"
+            "time": "2025-06-12T15:04:34+00:00"
         },
         {
             "name": "symfony/console",

--- a/konomi.php
+++ b/konomi.php
@@ -12,7 +12,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi;
+namespace SpaghettiDojo\Konomi;
 
 add_action(
     'plugins_loaded',

--- a/sources/ApiFetch/Module.php
+++ b/sources/ApiFetch/Module.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\ApiFetch;
+namespace SpaghettiDojo\Konomi\ApiFetch;
 
 use Psr\Container\ContainerInterface;
 use Inpsyde\Modularity\{
@@ -12,7 +12,7 @@ use Inpsyde\Modularity\{
     Properties\Properties
 };
 
-use function Widoz\Wp\Konomi\Functions\add_action_on_module_import;
+use function SpaghettiDojo\Konomi\Functions\add_action_on_module_import;
 
 class Module implements ServiceModule, ExecutableModule
 {

--- a/sources/Blocks/BlockRegistrar.php
+++ b/sources/Blocks/BlockRegistrar.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
 /**
  * @internal

--- a/sources/Blocks/Bookmark/Context.php
+++ b/sources/Blocks/Bookmark/Context.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks\Bookmark;
+namespace SpaghettiDojo\Konomi\Blocks\Bookmark;
 
-use Widoz\Wp\Konomi\User;
-use Widoz\Wp\Konomi\Blocks;
+use SpaghettiDojo\Konomi\User;
+use SpaghettiDojo\Konomi\Blocks;
 
 /**
  * @internal

--- a/sources/Blocks/Bookmark/render.php
+++ b/sources/Blocks/Bookmark/render.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks\Bookmark;
+namespace SpaghettiDojo\Konomi\Blocks\Bookmark;
 
-use Widoz\Wp\Konomi\Blocks;
+use SpaghettiDojo\Konomi\Blocks;
 
 $attributes = (array) ($attributes ?? null);
 

--- a/sources/Blocks/Context.php
+++ b/sources/Blocks/Context.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
 interface Context
 {

--- a/sources/Blocks/CustomProperty.php
+++ b/sources/Blocks/CustomProperty.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
 /**
  * @internal

--- a/sources/Blocks/InstanceId.php
+++ b/sources/Blocks/InstanceId.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
 /**
  * @internal

--- a/sources/Blocks/Konomi/Context.php
+++ b/sources/Blocks/Konomi/Context.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks\Konomi;
+namespace SpaghettiDojo\Konomi\Blocks\Konomi;
 
-use Widoz\Wp\Konomi\User;
-use Widoz\Wp\Konomi\Blocks;
+use SpaghettiDojo\Konomi\User;
+use SpaghettiDojo\Konomi\Blocks;
 
 /**
  * @internal

--- a/sources/Blocks/Konomi/partials/dialog.php
+++ b/sources/Blocks/Konomi/partials/dialog.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
-use Widoz\Wp\Konomi\Icons;
+use SpaghettiDojo\Konomi\Icons;
 
 $data = (array) ($data ?? null);
 

--- a/sources/Blocks/Konomi/partials/popover.php
+++ b/sources/Blocks/Konomi/partials/popover.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
 $data = (array) ($data ?? null);
 

--- a/sources/Blocks/Konomi/render.php
+++ b/sources/Blocks/Konomi/render.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks\Konomi;
+namespace SpaghettiDojo\Konomi\Blocks\Konomi;
 
-use Widoz\Wp\Konomi\Blocks;
+use SpaghettiDojo\Konomi\Blocks;
 
 $content = (string) ($content ?? null);
 

--- a/sources/Blocks/Module.php
+++ b/sources/Blocks/Module.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
 use Psr\Container\ContainerInterface;
 use Inpsyde\Modularity\{
@@ -11,14 +11,14 @@ use Inpsyde\Modularity\{
     Module\ServiceModule,
     Properties\Properties
 };
-use Widoz\Wp\Konomi\Blocks\{
+use SpaghettiDojo\Konomi\Blocks\{
     Rest\AddControllerFactory,
     Rest\AddSchemaFactory,
     Rest\AddResponse
 };
-use Widoz\Wp\Konomi\Rest;
-use Widoz\Wp\Konomi\User;
-use Widoz\Wp\Konomi\Post;
+use SpaghettiDojo\Konomi\Rest;
+use SpaghettiDojo\Konomi\User;
+use SpaghettiDojo\Konomi\Post;
 
 class Module implements ServiceModule, ExecutableModule
 {

--- a/sources/Blocks/PostContextTrait.php
+++ b/sources/Blocks/PostContextTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
 trait PostContextTrait
 {

--- a/sources/Blocks/Reaction/Context.php
+++ b/sources/Blocks/Reaction/Context.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks\Reaction;
+namespace SpaghettiDojo\Konomi\Blocks\Reaction;
 
-use Widoz\Wp\Konomi\Post;
-use Widoz\Wp\Konomi\User;
-use Widoz\Wp\Konomi\Blocks;
+use SpaghettiDojo\Konomi\Post;
+use SpaghettiDojo\Konomi\User;
+use SpaghettiDojo\Konomi\Blocks;
 
 /**
  * @internal

--- a/sources/Blocks/Reaction/render.php
+++ b/sources/Blocks/Reaction/render.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks\Reaction;
+namespace SpaghettiDojo\Konomi\Blocks\Reaction;
 
-use Widoz\Wp\Konomi\Blocks;
+use SpaghettiDojo\Konomi\Blocks;
 
 $attributes = (array) ($attributes ?? null);
 

--- a/sources/Blocks/Rest/AddController.php
+++ b/sources/Blocks/Rest/AddController.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks\Rest;
+namespace SpaghettiDojo\Konomi\Blocks\Rest;
 
-use Widoz\Wp\Konomi\Rest\Controller;
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\Rest\Controller;
+use SpaghettiDojo\Konomi\User;
 
 /**
  * @internal

--- a/sources/Blocks/Rest/AddControllerFactory.php
+++ b/sources/Blocks/Rest/AddControllerFactory.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks\Rest;
+namespace SpaghettiDojo\Konomi\Blocks\Rest;
 
-use Widoz\Wp\Konomi\Rest\Controller;
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\Rest\Controller;
+use SpaghettiDojo\Konomi\User;
 
 /**
  * @internal

--- a/sources/Blocks/Rest/AddResponse.php
+++ b/sources/Blocks/Rest/AddResponse.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks\Rest;
+namespace SpaghettiDojo\Konomi\Blocks\Rest;
 
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\User;
 
 class AddResponse
 {

--- a/sources/Blocks/Rest/AddSchema.php
+++ b/sources/Blocks/Rest/AddSchema.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks\Rest;
+namespace SpaghettiDojo\Konomi\Blocks\Rest;
 
-use Widoz\Wp\Konomi\Rest;
+use SpaghettiDojo\Konomi\Rest;
 
 /**
  * @internal

--- a/sources/Blocks/Rest/AddSchemaFactory.php
+++ b/sources/Blocks/Rest/AddSchemaFactory.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks\Rest;
+namespace SpaghettiDojo\Konomi\Blocks\Rest;
 
-use Widoz\Wp\Konomi\Rest\Schema;
+use SpaghettiDojo\Konomi\Rest\Schema;
 
 /**
  * @internal

--- a/sources/Blocks/Style.php
+++ b/sources/Blocks/Style.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
 /**
  * @internal

--- a/sources/Blocks/TemplateRender.php
+++ b/sources/Blocks/TemplateRender.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
 /**
  * @internal

--- a/sources/Blocks/UserContextTrait.php
+++ b/sources/Blocks/UserContextTrait.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\User;
 
 trait UserContextTrait
 {

--- a/sources/Blocks/api.php
+++ b/sources/Blocks/api.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
-use function Widoz\Wp\Konomi\package;
+use function SpaghettiDojo\Konomi\package;
 
 function context(string $contextName): Context
 {

--- a/sources/Blocks/partials/button.php
+++ b/sources/Blocks/partials/button.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Blocks;
+namespace SpaghettiDojo\Konomi\Blocks;
 
-use Widoz\Wp\Konomi\Icons;
+use SpaghettiDojo\Konomi\Icons;
 
 $data = (array) ($data ?? null);
 

--- a/sources/Configuration/Configuration.php
+++ b/sources/Configuration/Configuration.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Configuration;
+namespace SpaghettiDojo\Konomi\Configuration;
 
 use Inpsyde\Modularity;
 

--- a/sources/Configuration/ConfigurationInitScript.php
+++ b/sources/Configuration/ConfigurationInitScript.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Configuration;
+namespace SpaghettiDojo\Konomi\Configuration;
 
 class ConfigurationInitScript
 {

--- a/sources/Configuration/Module.php
+++ b/sources/Configuration/Module.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Configuration;
+namespace SpaghettiDojo\Konomi\Configuration;
 
 use Psr\Container\ContainerInterface;
 use Inpsyde\Modularity\{
@@ -12,7 +12,7 @@ use Inpsyde\Modularity\{
     Properties\Properties
 };
 
-use function Widoz\Wp\Konomi\Functions\add_action_on_module_import;
+use function SpaghettiDojo\Konomi\Functions\add_action_on_module_import;
 
 class Module implements ServiceModule, ExecutableModule
 {

--- a/sources/Functions/filters.php
+++ b/sources/Functions/filters.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Functions;
+namespace SpaghettiDojo\Konomi\Functions;
 
 /**
  * @api

--- a/sources/Icons/Module.php
+++ b/sources/Icons/Module.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Icons;
+namespace SpaghettiDojo\Konomi\Icons;
 
 use Psr\Container\ContainerInterface;
 use Inpsyde\Modularity\{
@@ -11,7 +11,7 @@ use Inpsyde\Modularity\{
     Module\ModuleClassNameIdTrait,
     Properties\Properties
 };
-use Widoz\Wp\Konomi\Configuration;
+use SpaghettiDojo\Konomi\Configuration;
 
 class Module implements ServiceModule, ExecutableModule
 {

--- a/sources/Icons/Render.php
+++ b/sources/Icons/Render.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Icons;
+namespace SpaghettiDojo\Konomi\Icons;
 
-use Widoz\Wp\Konomi\Configuration;
+use SpaghettiDojo\Konomi\Configuration;
 
 /**
  * @api

--- a/sources/Icons/api.php
+++ b/sources/Icons/api.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Icons;
+namespace SpaghettiDojo\Konomi\Icons;
 
-use function Widoz\Wp\Konomi\package;
+use function SpaghettiDojo\Konomi\package;
 
 function icon(): Render
 {

--- a/sources/Post/Module.php
+++ b/sources/Post/Module.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Post;
+namespace SpaghettiDojo\Konomi\Post;
 
 use Psr\Container\ContainerInterface;
 use Inpsyde\Modularity\{
@@ -10,7 +10,7 @@ use Inpsyde\Modularity\{
     Module\ExecutableModule,
     Module\ModuleClassNameIdTrait
 };
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\User;
 
 class Module implements ServiceModule, ExecutableModule
 {

--- a/sources/Post/Post.php
+++ b/sources/Post/Post.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Post;
+namespace SpaghettiDojo\Konomi\Post;
 
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\User;
 
 /**
  * @api

--- a/sources/Post/RawDataAssert.php
+++ b/sources/Post/RawDataAssert.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Post;
+namespace SpaghettiDojo\Konomi\Post;
 
 /**
  * @internal

--- a/sources/Post/Repository.php
+++ b/sources/Post/Repository.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Post;
+namespace SpaghettiDojo\Konomi\Post;
 
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\User;
 
 /**
  * @internal

--- a/sources/Post/Storage.php
+++ b/sources/Post/Storage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Post;
+namespace SpaghettiDojo\Konomi\Post;
 
 /**
  * @internal

--- a/sources/Post/StorageKey.php
+++ b/sources/Post/StorageKey.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Post;
+namespace SpaghettiDojo\Konomi\Post;
 
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\User;
 
 class StorageKey
 {

--- a/sources/Rest/Controller.php
+++ b/sources/Rest/Controller.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Rest;
+namespace SpaghettiDojo\Konomi\Rest;
 
 interface Controller
 {

--- a/sources/Rest/Method.php
+++ b/sources/Rest/Method.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Rest;
+namespace SpaghettiDojo\Konomi\Rest;
 
 /**
  * @internal

--- a/sources/Rest/Middleware.php
+++ b/sources/Rest/Middleware.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Rest;
+namespace SpaghettiDojo\Konomi\Rest;
 
 /**
  * @phpstan-type MiddlewareCallable = callable(\WP_REST_Request): (\WP_REST_Response|\WP_Error)

--- a/sources/Rest/MiddlewareProcess.php
+++ b/sources/Rest/MiddlewareProcess.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Rest;
+namespace SpaghettiDojo\Konomi\Rest;
 
 /**
  * @internal

--- a/sources/Rest/Middlewares/Authentication.php
+++ b/sources/Rest/Middlewares/Authentication.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Rest\Middlewares;
+namespace SpaghettiDojo\Konomi\Rest\Middlewares;
 
-use Widoz\Wp\Konomi\Rest;
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\Rest;
+use SpaghettiDojo\Konomi\User;
 
 class Authentication implements Rest\Middleware
 {

--- a/sources/Rest/Middlewares/ErrorCatch.php
+++ b/sources/Rest/Middlewares/ErrorCatch.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Rest\Middlewares;
+namespace SpaghettiDojo\Konomi\Rest\Middlewares;
 
-use Widoz\Wp\Konomi\Rest\Middleware;
+use SpaghettiDojo\Konomi\Rest\Middleware;
 
 class ErrorCatch implements Middleware
 {

--- a/sources/Rest/Module.php
+++ b/sources/Rest/Module.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Rest;
+namespace SpaghettiDojo\Konomi\Rest;
 
 use Psr\Container\ContainerInterface;
 use Inpsyde\Modularity\{
     Module\ServiceModule,
     Module\ModuleClassNameIdTrait
 };
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\User;
 
 class Module implements ServiceModule
 {

--- a/sources/Rest/RestRegistTrait.php
+++ b/sources/Rest/RestRegistTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Rest;
+namespace SpaghettiDojo\Konomi\Rest;
 
 trait RestRegistTrait
 {

--- a/sources/Rest/Route.php
+++ b/sources/Rest/Route.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Rest;
+namespace SpaghettiDojo\Konomi\Rest;
 
 /**
  * @api

--- a/sources/Rest/Schema.php
+++ b/sources/Rest/Schema.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Rest;
+namespace SpaghettiDojo\Konomi\Rest;
 
 /**
  * @api

--- a/sources/User/CurrentUser.php
+++ b/sources/User/CurrentUser.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 /**
  * @internal

--- a/sources/User/Item.php
+++ b/sources/User/Item.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 /**
  * @api

--- a/sources/User/ItemFactory.php
+++ b/sources/User/ItemFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 /**
  * @api

--- a/sources/User/ItemGroup.php
+++ b/sources/User/ItemGroup.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 /**
  * @api

--- a/sources/User/ItemRegistry.php
+++ b/sources/User/ItemRegistry.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 /**
  * @internal

--- a/sources/User/ItemRegistryKey.php
+++ b/sources/User/ItemRegistryKey.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 /**
  * @internal

--- a/sources/User/Module.php
+++ b/sources/User/Module.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 use Psr\Container\ContainerInterface;
 use Inpsyde\Modularity\{

--- a/sources/User/RawDataAssert.php
+++ b/sources/User/RawDataAssert.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 /**
  * @internal

--- a/sources/User/Repository.php
+++ b/sources/User/Repository.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 /**
  * @internal

--- a/sources/User/Storage.php
+++ b/sources/User/Storage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 /**
  * @internal

--- a/sources/User/StorageKey.php
+++ b/sources/User/StorageKey.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\User;
 
 class StorageKey
 {

--- a/sources/User/User.php
+++ b/sources/User/User.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 /**
  * @api

--- a/sources/User/UserFactory.php
+++ b/sources/User/UserFactory.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\User;
+namespace SpaghettiDojo\Konomi\User;
 
 /**
  * @api

--- a/sources/package.php
+++ b/sources/package.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi;
+namespace SpaghettiDojo\Konomi;
 
 use Inpsyde\Modularity;
 

--- a/tests/functional/php/Functions/FiltersTest.php
+++ b/tests/functional/php/Functions/FiltersTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Integration\Functions;
+namespace SpaghettiDojo\Konomi\Tests\Integration\Functions;
 
-use function Widoz\Wp\Konomi\Functions\add_single_conditional_filter;
-use function Widoz\Wp\Konomi\Functions\add_action_on_module_import;
+use function SpaghettiDojo\Konomi\Functions\add_single_conditional_filter;
+use function SpaghettiDojo\Konomi\Functions\add_action_on_module_import;
 
 beforeAll(function (): void {
     setUpHooks();

--- a/tests/integration/php/AssetsTest.php
+++ b/tests/integration/php/AssetsTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Integration\ApiFetch;
+namespace SpaghettiDojo\Konomi\Tests\Integration\ApiFetch;
 
-use Widoz\Wp\Konomi\ApiFetch;
-use Widoz\Wp\Konomi\Configuration;
-use Widoz\Wp\Konomi\Icons;
+use SpaghettiDojo\Konomi\ApiFetch;
+use SpaghettiDojo\Konomi\Configuration;
+use SpaghettiDojo\Konomi\Icons;
 
 beforeEach(function (): void {
     setupWpConstants();

--- a/tests/integration/php/PostRepositoryTest.php
+++ b/tests/integration/php/PostRepositoryTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Integration\Post;
+namespace SpaghettiDojo\Konomi\Tests\Integration\Post;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\Post;
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\Post;
+use SpaghettiDojo\Konomi\User;
 
 beforeEach(function (): void {
     $this->wpUser = \Mockery::mock('\WP_User');

--- a/tests/integration/php/RegisterRestEndpointsTest.php
+++ b/tests/integration/php/RegisterRestEndpointsTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Integration\Rest;
+namespace SpaghettiDojo\Konomi\Tests\Integration\Rest;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\Rest;
+use SpaghettiDojo\Konomi\Rest;
 
 beforeAll(function (): void {
     setUpWpRest();

--- a/tests/integration/php/UserRepositoryTest.php
+++ b/tests/integration/php/UserRepositoryTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Integration;
+namespace SpaghettiDojo\Konomi\Tests\Integration;
 
 use Brain\Monkey\Actions;
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\User;
 
 beforeAll(function (): void {
     $wpUser = \Mockery::mock(\WP_User::class);

--- a/tests/unit/php/Blocks/BlockRegistrarTest.php
+++ b/tests/unit/php/Blocks/BlockRegistrarTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Blocks;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Blocks;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\Blocks\BlockRegistrar;
+use SpaghettiDojo\Konomi\Blocks\BlockRegistrar;
 
 describe('registerBlockTypes', function (): void {
     it('register all blocks in the blocks directory', function (): void {

--- a/tests/unit/php/Blocks/Bookmark/ContextTest.php
+++ b/tests/unit/php/Blocks/Bookmark/ContextTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Blocks;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Blocks;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\Blocks;
-use Widoz\Wp\Konomi\User;
-use Widoz\Wp\Konomi\Blocks\Bookmark\Context;
+use SpaghettiDojo\Konomi\Blocks;
+use SpaghettiDojo\Konomi\User;
+use SpaghettiDojo\Konomi\Blocks\Bookmark\Context;
 
 describe('toArray', function (): void {
     it('ensure valid serialization', function (): void {

--- a/tests/unit/php/Blocks/CustomPropertyTest.php
+++ b/tests/unit/php/Blocks/CustomPropertyTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Blocks;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Blocks;
 
-use Widoz\Wp\Konomi\Blocks\CustomProperty;
+use SpaghettiDojo\Konomi\Blocks\CustomProperty;
 
 describe('isValid', function (): void {
     it('Instantiate a valid key value pair', function (): void {

--- a/tests/unit/php/Blocks/Konomi/ContextTest.php
+++ b/tests/unit/php/Blocks/Konomi/ContextTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Blocks;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Blocks;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\Blocks;
-use Widoz\Wp\Konomi\User;
-use Widoz\Wp\Konomi\Blocks\Konomi\Context;
+use SpaghettiDojo\Konomi\Blocks;
+use SpaghettiDojo\Konomi\User;
+use SpaghettiDojo\Konomi\Blocks\Konomi\Context;
 
 describe('toArray', function (): void {
     it('ensure valid serialization', function (): void {

--- a/tests/unit/php/Blocks/Like/ContextTest.php
+++ b/tests/unit/php/Blocks/Like/ContextTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Blocks;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Blocks;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\Blocks;
-use Widoz\Wp\Konomi\Post;
-use Widoz\Wp\Konomi\User;
-use Widoz\Wp\Konomi\Blocks\Reaction\Context;
+use SpaghettiDojo\Konomi\Blocks;
+use SpaghettiDojo\Konomi\Post;
+use SpaghettiDojo\Konomi\User;
+use SpaghettiDojo\Konomi\Blocks\Reaction\Context;
 
 describe('toArray', function (): void {
     it('ensure valid serialization', function (): void {

--- a/tests/unit/php/Blocks/Rest/AddControllerTest.php
+++ b/tests/unit/php/Blocks/Rest/AddControllerTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Blocks\Rest;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Blocks\Rest;
 
 use Mockery;
-use Widoz\Wp\Konomi\Blocks;
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\Blocks;
+use SpaghettiDojo\Konomi\User;
 
 beforeAll(function (): void {
     setUpWpRest();

--- a/tests/unit/php/Blocks/Rest/AddSchemaTest.php
+++ b/tests/unit/php/Blocks/Rest/AddSchemaTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Blocks\Rest;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Blocks\Rest;
 
-use Widoz\Wp\Konomi\Blocks;
+use SpaghettiDojo\Konomi\Blocks;
 
 describe('toArray', function (): void {
     it('should return the correct schema', function (): void {

--- a/tests/unit/php/Blocks/StyleTest.php
+++ b/tests/unit/php/Blocks/StyleTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Blocks;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Blocks;
 
-use Widoz\Wp\Konomi\Blocks\Style;
-use Widoz\Wp\Konomi\Blocks\CustomProperty;
+use SpaghettiDojo\Konomi\Blocks\Style;
+use SpaghettiDojo\Konomi\Blocks\CustomProperty;
 
 describe('__toString', function (): void {
     it('reduce given properties to css string', function (): void {

--- a/tests/unit/php/Blocks/TemplateRenderTest.php
+++ b/tests/unit/php/Blocks/TemplateRenderTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Blocks;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Blocks;
 
 use Brain\Monkey\Functions;
 use Brain\Monkey\Filters;
-use Widoz\Wp\Konomi\Blocks\TemplateRender;
+use SpaghettiDojo\Konomi\Blocks\TemplateRender;
 
 describe('render', function (): void {
     it('render a template with given arguments', function (): void {

--- a/tests/unit/php/Configuration/ConfigurationInitScriptTest.php
+++ b/tests/unit/php/Configuration/ConfigurationInitScriptTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Configuration;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Configuration;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\Configuration;
+use SpaghettiDojo\Konomi\Configuration;
 
 describe('printModuleConfigurationInitializer', function (): void {
     it('render a js module calling the client initConfiguration function', function (): void {

--- a/tests/unit/php/Configuration/ConfigurationTest.php
+++ b/tests/unit/php/Configuration/ConfigurationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Configuration;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Configuration;
 
 describe('serialize', function (): void {
     it('Serialize the given configuration', function (): void {
@@ -13,7 +13,7 @@ describe('serialize', function (): void {
         $properties->shouldReceive('isDebug')->andReturn(true);
 
         $expected = '{"iconsUrl":"http:\/\/example.com\/\/path\/to\/icons","iconsPath":"\/var\/www\/html\/\/path\/to\/icons","isDebugMode":true}';
-        $configuration = \Widoz\Wp\Konomi\Configuration\Configuration::new($properties, '/path/to/icons');
+        $configuration = \SpaghettiDojo\Konomi\Configuration\Configuration::new($properties, '/path/to/icons');
         expect($configuration->serialize())->toBe($expected);
     });
 });

--- a/tests/unit/php/Icons/RenderTest.php
+++ b/tests/unit/php/Icons/RenderTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use Widoz\Wp\Konomi\Configuration;
-use Widoz\Wp\Konomi\Icons;
+use SpaghettiDojo\Konomi\Configuration;
+use SpaghettiDojo\Konomi\Icons;
 use org\bovigo\vfs\vfsStream;
 use Brain\Monkey\Functions;
 

--- a/tests/unit/php/PackageTest.php
+++ b/tests/unit/php/PackageTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit;
+namespace SpaghettiDojo\Konomi\Tests\Unit;
 
 use Brain\Monkey\Functions;
 

--- a/tests/unit/php/Post/PostTest.php
+++ b/tests/unit/php/Post/PostTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Post;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Post;
 
-use Widoz\Wp\Konomi\Post\{
+use SpaghettiDojo\Konomi\Post\{
     Post,
     Repository
 };
-use Widoz\Wp\Konomi\User\{Item, ItemGroup};
+use SpaghettiDojo\Konomi\User\{Item, ItemGroup};
 use Mockery;
 
 beforeEach(function (): void {

--- a/tests/unit/php/Post/RawDataAssertTest.php
+++ b/tests/unit/php/Post/RawDataAssertTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Post;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Post;
 
-use Widoz\Wp\Konomi\Post\RawDataAssert;
+use SpaghettiDojo\Konomi\Post\RawDataAssert;
 
 beforeEach(function (): void {
     $this->rawDataAsserter = RawDataAssert::new();

--- a/tests/unit/php/Post/StorageKeyTest.php
+++ b/tests/unit/php/Post/StorageKeyTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Post;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Post;
 
-use Widoz\Wp\Konomi\Post\StorageKey;
-use Widoz\Wp\Konomi\User\ItemGroup;
+use SpaghettiDojo\Konomi\Post\StorageKey;
+use SpaghettiDojo\Konomi\User\ItemGroup;
 
 describe('new', function (): void {
     it('creates a new instance with a valid base key', function (): void {

--- a/tests/unit/php/Post/StorageTest.php
+++ b/tests/unit/php/Post/StorageTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Post;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Post;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\Post\Storage;
+use SpaghettiDojo\Konomi\Post\Storage;
 
 describe('Storage', function (): void {
     it('read data from the storage', function (): void {

--- a/tests/unit/php/Rest/MiddlewareProcessTest.php
+++ b/tests/unit/php/Rest/MiddlewareProcessTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Rest;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Rest;
 
-use Widoz\Wp\Konomi\Rest\MiddlewareProcess;
-use Widoz\Wp\Konomi\Rest\Middleware;
+use SpaghettiDojo\Konomi\Rest\MiddlewareProcess;
+use SpaghettiDojo\Konomi\Rest\Middleware;
 
 beforeAll(function (): void {
     setUpWpRest();

--- a/tests/unit/php/Rest/Middlewares/AuthenticationTest.php
+++ b/tests/unit/php/Rest/Middlewares/AuthenticationTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Rest\Middlewares;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Rest\Middlewares;
 
-use Widoz\Wp\Konomi\Rest\Middlewares\Authentication;
-use Widoz\Wp\Konomi\User\User;
+use SpaghettiDojo\Konomi\Rest\Middlewares\Authentication;
+use SpaghettiDojo\Konomi\User\User;
 
 beforeAll(function (): void {
     setUpWpRest();

--- a/tests/unit/php/Rest/Middlewares/ErrorCatchTest.php
+++ b/tests/unit/php/Rest/Middlewares/ErrorCatchTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\Rest\Middlewares;
+namespace SpaghettiDojo\Konomi\Tests\Unit\Rest\Middlewares;
 
-use Widoz\Wp\Konomi\Rest\Middlewares\ErrorCatch;
+use SpaghettiDojo\Konomi\Rest\Middlewares\ErrorCatch;
 
 beforeAll(function (): void {
     setUpWpRest();

--- a/tests/unit/php/User/CurrentUserTest.php
+++ b/tests/unit/php/User/CurrentUserTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\User;
+namespace SpaghettiDojo\Konomi\Tests\Unit\User;
 
 use Mockery;
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\User;
 
 beforeEach(function (): void {
     $this->wpUser = Mockery::mock('\WP_User');

--- a/tests/unit/php/User/ItemGroupTest.php
+++ b/tests/unit/php/User/ItemGroupTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\User;
+namespace SpaghettiDojo\Konomi\Tests\Unit\User;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\User\ItemGroup;
+use SpaghettiDojo\Konomi\User\ItemGroup;
 
 beforeEach(function (): void {
     Functions\when('esc_html')->returnArg();
@@ -31,6 +31,6 @@ describe('fromValue', function (): void {
 
     it('throws ValueError when given an invalid value', function (): void {
         expect(fn () => ItemGroup::fromValue('invalid'))
-            ->toThrow(\ValueError::class, 'invalid is not a valid backing value for enum Widoz\Wp\Konomi\User\ItemGroup');
+            ->toThrow(\ValueError::class, 'invalid is not a valid backing value for enum SpaghettiDojo\Konomi\User\ItemGroup');
     });
 });

--- a/tests/unit/php/User/ItemRegistryKeyTest.php
+++ b/tests/unit/php/User/ItemRegistryKeyTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\User;
+namespace SpaghettiDojo\Konomi\Tests\Unit\User;
 
 use Mockery;
-use Widoz\Wp\Konomi\User\{
+use SpaghettiDojo\Konomi\User\{
     ItemGroup,
     ItemRegistryKey,
     User

--- a/tests/unit/php/User/ItemRegistryTest.php
+++ b/tests/unit/php/User/ItemRegistryTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\User;
+namespace SpaghettiDojo\Konomi\Tests\Unit\User;
 
-use Widoz\Wp\Konomi\User\{
+use SpaghettiDojo\Konomi\User\{
     ItemGroup,
     ItemRegistryKey,
     ItemRegistry,

--- a/tests/unit/php/User/LikeFactoryTest.php
+++ b/tests/unit/php/User/LikeFactoryTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\User;
+namespace SpaghettiDojo\Konomi\Tests\Unit\User;
 
-use Widoz\Wp\Konomi\User\{ItemFactory, Item, ItemGroup};
+use SpaghettiDojo\Konomi\User\{ItemFactory, Item, ItemGroup};
 
 describe('ItemFactory', function (): void {
     it('should create a new Item instance', function (): void {

--- a/tests/unit/php/User/RawDataAssertTest.php
+++ b/tests/unit/php/User/RawDataAssertTest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\User;
+namespace SpaghettiDojo\Konomi\Tests\Unit\User;
 
-use Widoz\Wp\Konomi\User\RawDataAssert;
+use SpaghettiDojo\Konomi\User\RawDataAssert;
 
 beforeEach(function (): void {
     $this->rawDataAsserter = RawDataAssert::new();

--- a/tests/unit/php/User/StorageKeyTest.php
+++ b/tests/unit/php/User/StorageKeyTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\User;
+namespace SpaghettiDojo\Konomi\Tests\Unit\User;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\User\StorageKey;
-use Widoz\Wp\Konomi\User\ItemGroup;
+use SpaghettiDojo\Konomi\User\StorageKey;
+use SpaghettiDojo\Konomi\User\ItemGroup;
 
 describe('new', function (): void {
     it('creates a new instance with a valid base key', function (): void {

--- a/tests/unit/php/User/StorageTest.php
+++ b/tests/unit/php/User/StorageTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Widoz\Wp\Konomi\Tests\Unit\User;
+namespace SpaghettiDojo\Konomi\Tests\Unit\User;
 
 use Brain\Monkey\Functions;
-use Widoz\Wp\Konomi\User;
+use SpaghettiDojo\Konomi\User;
 
 beforeEach(function (): void {
     $this->storage = User\Storage::new();


### PR DESCRIPTION
Refactor all namespaces across the project from `Widoz\Wp\Konomi` to `SpaghettiDojo\Konomi`, including source files, tests, and GitHub workflows. Update references in the composer file, README badges, and unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated all namespaces and related references from the previous organization to the new organization name throughout the codebase, tests, and documentation.
  - Updated package name and autoload configuration to reflect the new organization in project metadata.
  - Adjusted badge URLs in documentation to point to the new repository location.

- **Documentation**
  - Updated README badges and links to reference the new organization and repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->